### PR TITLE
feat: refresh vhs overlay and add intensity slider

### DIFF
--- a/src/pages/gameData.ts
+++ b/src/pages/gameData.ts
@@ -70,6 +70,7 @@ export interface Translations {
     };
     audio: string;
     musicVolume: string;
+    vhsEffect: string;
     music: {
       label: string;
       on: string;
@@ -361,6 +362,7 @@ const translationsES: Translations = {
     },
     audio: "Audio",
     musicVolume: "Volumen de la música",
+    vhsEffect: "Intensidad VHS",
     music: {
       label: "Música",
       on: "Activa",
@@ -484,6 +486,7 @@ const translationsEN: Translations = {
     },
     audio: "Audio",
     musicVolume: "Music volume",
+    vhsEffect: "VHS effect intensity",
     music: {
       label: "Music",
       on: "On",


### PR DESCRIPTION
## Summary
- redesign the CRT/VHS overlay with jitter, grain, and distortion that scales with player-selected intensity
- add a VHS effect intensity slider to the pause menu audio panel with persistence and updated translations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ed59f6cc988326869e620a9380983e